### PR TITLE
Set runtime logging to info for performance runs

### DIFF
--- a/scripts/perf/env.json
+++ b/scripts/perf/env.json
@@ -5,7 +5,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FILTER": "restate=info",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,log-server,admin,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",
@@ -25,7 +25,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FILTER": "restate=info",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,admin,log-server,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",
@@ -46,7 +46,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FILTER": "restate=info",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,admin,log-server,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",


### PR DESCRIPTION
Set runtime logging to info for performance runs. This should be merged once the current performance tests for 1.2.2 and 1.2.0 have completed. In 1.2.0 we are still logging excessively on info logging.