### PR TITLE
Schedule forward, backward and random compatibility verification tests

### DIFF
--- a/.github/workflows/verification-compatability.yaml
+++ b/.github/workflows/verification-compatability.yaml
@@ -1,6 +1,18 @@
 name: Verification Compatibility tests
 
 on:
+  workflow_call:
+    inputs:
+      sdkImage:
+        description: "sdk image, will use 'ghcr.io/restatedev/test-services-node:main' when unspecified"
+        required: false
+        default: "ghcr.io/restatedev/test-services-node:main"
+        type: string
+      mode:
+        type: string
+        description: "compatibility test mode (forward: from old to new version, backward: from new to old version, random: back and forth between versions)"
+        required: false
+        default: "forward"
   workflow_dispatch: # To start from UI
     inputs:
       sdkImage:
@@ -15,8 +27,6 @@ on:
           - forward
           - backward
           - random
-  schedule:
-    - cron: "12 0 * * *" # 00:12am UTC daily
 
 env:
   REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/verification-compatibility-backward.yaml
+++ b/.github/workflows/verification-compatibility-backward.yaml
@@ -1,0 +1,14 @@
+name: Verification Compatibility Backward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "12 0 * * *" # 00:12am UTC daily
+
+jobs:
+  verification-compatibility-backward:
+    name: Verification Compatibility Backward
+    uses: ./.github/workflows/verification-compatibility.yml
+    secrets: inherit
+    with:
+      mode: backward

--- a/.github/workflows/verification-compatibility-forward.yaml
+++ b/.github/workflows/verification-compatibility-forward.yaml
@@ -1,0 +1,14 @@
+name: Verification Compatibility Forward
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "12 0 * * *" # 00:12am UTC daily
+
+jobs:
+  verification-compatibility-forward:
+    name: Verification Compatibility Forward
+    uses: ./.github/workflows/verification-compatibility.yml
+    secrets: inherit
+    with:
+      mode: forward

--- a/.github/workflows/verification-compatibility-random.yaml
+++ b/.github/workflows/verification-compatibility-random.yaml
@@ -1,0 +1,14 @@
+name: Verification Compatibility Random
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "12 0 * * *" # 00:12am UTC daily
+
+jobs:
+  verification-compatibility-random:
+    name: Verification Compatibility Random
+    uses: ./.github/workflows/verification-compatibility.yml
+    secrets: inherit
+    with:
+      mode: random


### PR DESCRIPTION
This commit enables the forward, backward and random compatibility tests to run on scheduled basis (regularly).