### PR TITLE
Control the test services max concurrent streams via env var

### DIFF
--- a/scripts/perf/env.json
+++ b/scripts/perf/env.json
@@ -1,7 +1,11 @@
 {
   "n1": {
     "image": "${RESTATE_CONTAINER_IMAGE}",
-    "ports": [8080, 9070, 5122],
+    "ports": [
+      8080,
+      9070,
+      5122
+    ],
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
@@ -14,14 +18,14 @@
       "RESTATE_METADATA_SERVER__TYPE": "replicated",
       "RESTATE_AUTO_PROVISION": "true",
       "RESTATE_ADVERTISED_ADDRESS": "http://n1:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
-      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
   "n2": {
     "image": "${RESTATE_CONTAINER_IMAGE}",
-    "ports": [8080],
+    "ports": [
+      8080
+    ],
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
@@ -35,14 +39,14 @@
       "RESTATE_AUTO_PROVISION": "false",
       "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
       "RESTATE_ADVERTISED_ADDRESS": "http://n2:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
-      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
   "n3": {
     "image": "${RESTATE_CONTAINER_IMAGE}",
-    "ports": [8080],
+    "ports": [
+      8080
+    ],
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
@@ -56,8 +60,6 @@
       "RESTATE_AUTO_PROVISION": "false",
       "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
       "RESTATE_ADVERTISED_ADDRESS": "http://n3:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
-      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
@@ -71,7 +73,8 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL0"
+      "SERVICES": "ObjectInterpreterL0",
+      "MAX_CONCURRENT_STREAMS": "256"
     }
   },
   "interpreter_one": {
@@ -84,7 +87,8 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL1"
+      "SERVICES": "ObjectInterpreterL1",
+      "MAX_CONCURRENT_STREAMS": "256"
     }
   },
   "interpreter_two": {
@@ -97,7 +101,8 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL2"
+      "SERVICES": "ObjectInterpreterL2",
+      "MAX_CONCURRENT_STREAMS": "256"
     }
   },
   "services": {
@@ -110,7 +115,8 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ServiceInterpreterHelper"
+      "SERVICES": "ServiceInterpreterHelper",
+      "MAX_CONCURRENT_STREAMS": "256"
     }
   }
 }


### PR DESCRIPTION
Control the test services max concurrent streams via env var

Summary:
Use the `MAX_CONCURRENT_STREAMS` instead of setting the deprecated restate server concurrency limit

Depends on https://github.com/restatedev/sdk-typescript/pull/543
