### PR TITLE
Use the correct env var for logging

### DIFF
--- a/scripts/perf/env.json
+++ b/scripts/perf/env.json
@@ -72,7 +72,7 @@
     "pull": "always",
     "env": {
       "PORT": "9000",
-      "RESTATE_LOG_LEVEL": "ERROR",
+      "RESTATE_LOGGING": "ERROR",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
@@ -86,7 +86,7 @@
     "pull": "always",
     "env": {
       "PORT": "9001",
-      "RESTATE_LOG_LEVEL": "ERROR",
+      "RESTATE_LOGGING": "ERROR",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
@@ -100,7 +100,7 @@
     "pull": "always",
     "env": {
       "PORT": "9002",
-      "RESTATE_LOG_LEVEL": "ERROR",
+      "RESTATE_LOGGING": "ERROR",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
@@ -114,7 +114,7 @@
     "pull": "always",
     "env": {
       "PORT": "9003",
-      "RESTATE_LOG_LEVEL": "ERROR",
+      "RESTATE_LOGGING": "ERROR",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",


### PR DESCRIPTION
Use the correct env var for logging

Summary:
Use the correct env var for logging. [Here](https://github.com/restatedev/sdk-typescript/blob/13e896fdf2a9358278688505f67492c2e584e4a3/packages/restate-sdk/src/logging/console_logger_transport.ts#L57) it shows
the env var is actually RESTATE_LOGGING not RESTATE_LOG_LEVEL
