### PR TITLE
Supress test logs

### DIFF
--- a/scripts/perf/env.json
+++ b/scripts/perf/env.json
@@ -9,7 +9,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=info",
+      "RESTATE_LOG_FILTER": "restate=error",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,log-server,admin,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",
@@ -30,7 +30,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=info",
+      "RESTATE_LOG_FILTER": "restate=error",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,admin,log-server,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",
@@ -52,7 +52,7 @@
     "pull": "always",
     "env": {
       "RUST_BACKTRACE": "full",
-      "RESTATE_LOG_FILTER": "restate=info",
+      "RESTATE_LOG_FILTER": "restate=error",
       "RESTATE_LOG_FORMAT": "json",
       "RESTATE_ROLES": "[worker,admin,log-server,metadata-server]",
       "RESTATE_CLUSTER_NAME": "foobar",
@@ -86,7 +86,7 @@
     "pull": "always",
     "env": {
       "PORT": "9001",
-      "RESTATE_LOGGING": "ERROR",
+      "RESTATE_LOGGING": "FATAL",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
@@ -100,7 +100,7 @@
     "pull": "always",
     "env": {
       "PORT": "9002",
-      "RESTATE_LOGGING": "ERROR",
+      "RESTATE_LOGGING": "FATAL",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
@@ -114,7 +114,7 @@
     "pull": "always",
     "env": {
       "PORT": "9003",
-      "RESTATE_LOGGING": "ERROR",
+      "RESTATE_LOGGING": "FATAL",
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",


### PR DESCRIPTION
Supress test logs

Summary:
Sets the runtime loglevel to ERROR. Also sets the test service log-level to FATAL

> This depends on this [PR](https://github.com/restatedev/sdk-typescript/pull/549)
