### PR TITLE
Revert back to runtime concurrency limit

### DIFF
--- a/scripts/perf/env.json
+++ b/scripts/perf/env.json
@@ -18,7 +18,8 @@
       "RESTATE_METADATA_SERVER__TYPE": "replicated",
       "RESTATE_AUTO_PROVISION": "true",
       "RESTATE_ADVERTISED_ADDRESS": "http://n1:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "1000",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
@@ -40,7 +41,8 @@
       "RESTATE_AUTO_PROVISION": "false",
       "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
       "RESTATE_ADVERTISED_ADDRESS": "http://n2:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "1000",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
@@ -62,7 +64,8 @@
       "RESTATE_AUTO_PROVISION": "false",
       "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
       "RESTATE_ADVERTISED_ADDRESS": "http://n3:5122",
-      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "1000",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
       "DO_NOT_TRACK": "true"
     }
   },
@@ -76,8 +79,7 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL0",
-      "MAX_CONCURRENT_STREAMS": "256"
+      "SERVICES": "ObjectInterpreterL0"
     }
   },
   "interpreter_one": {
@@ -90,8 +92,7 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL1",
-      "MAX_CONCURRENT_STREAMS": "256"
+      "SERVICES": "ObjectInterpreterL1"
     }
   },
   "interpreter_two": {
@@ -104,8 +105,7 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ObjectInterpreterL2",
-      "MAX_CONCURRENT_STREAMS": "256"
+      "SERVICES": "ObjectInterpreterL2"
     }
   },
   "services": {
@@ -118,8 +118,7 @@
       "NODE_ENV": "production",
       "UV_THREADPOOL_SIZE": "8",
       "NODE_OPTS": "--max-old-space-size=4096",
-      "SERVICES": "ServiceInterpreterHelper",
-      "MAX_CONCURRENT_STREAMS": "256"
+      "SERVICES": "ServiceInterpreterHelper"
     }
   }
 }


### PR DESCRIPTION
Revert back to runtime concurrency limit

Summary:
- Use runtime concurrency limit instead of h2 max concurrent streams
- Use 1s inactivity timeout
