### PR TITLE
Add matrix of different base images for comptability tests

### DIFF
--- a/.github/workflows/verification-compatibility-backward.yaml
+++ b/.github/workflows/verification-compatibility-backward.yaml
@@ -8,7 +8,15 @@ on:
 jobs:
   verification-compatibility-backward:
     name: Verification Compatibility Backward
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each released image below is run as a compatibility base against restate:main.
+        releasedImage:
+          - restatedev/restate:1.6.2
+          - restatedev/restate:1.7.0
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:
       mode: backward
+      releasedImage: ${{ matrix.releasedImage }}

--- a/.github/workflows/verification-compatibility-forward.yaml
+++ b/.github/workflows/verification-compatibility-forward.yaml
@@ -8,7 +8,15 @@ on:
 jobs:
   verification-compatibility-forward:
     name: Verification Compatibility Forward
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each released image below is run as a compatibility base against restate:main.
+        releasedImage:
+          - restatedev/restate:1.6.2
+          - restatedev/restate:1.7.0
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:
       mode: forward
+      releasedImage: ${{ matrix.releasedImage }}

--- a/.github/workflows/verification-compatibility-random.yaml
+++ b/.github/workflows/verification-compatibility-random.yaml
@@ -8,7 +8,15 @@ on:
 jobs:
   verification-compatibility-random:
     name: Verification Compatibility Random
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each released image below is run as a compatibility base against restate:main.
+        releasedImage:
+          - restatedev/restate:1.6.2
+          - restatedev/restate:1.7.0
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:
       mode: random
+      releasedImage: ${{ matrix.releasedImage }}

--- a/.github/workflows/verification-compatibility.yaml
+++ b/.github/workflows/verification-compatibility.yaml
@@ -13,6 +13,10 @@ on:
         description: "compatibility test mode (forward: from old to new version, backward: from new to old version, random: back and forth between versions)"
         required: false
         default: "forward"
+      releasedImage:
+        description: "released restate image to use as the compatibility base (upgraded to/from ghcr.io/restatedev/restate:main)"
+        required: true
+        type: string
       restateLogFilter:
         description: "RESTATE_LOG_FILTER for the runtime nodes (e.g. restate=info)"
         required: false
@@ -32,6 +36,11 @@ on:
           - forward
           - backward
           - random
+      releasedImage:
+        description: "released restate image to use as the compatibility base (upgraded to/from ghcr.io/restatedev/restate:main)"
+        required: false
+        default: "restatedev/restate:1.6.2"
+        type: string
       restateLogFilter:
         description: "RESTATE_LOG_FILTER for the runtime nodes (e.g. restate=info)"
         required: false
@@ -46,7 +55,7 @@ env:
 
 jobs:
   build:
-    name: Compatibility tests (${{ inputs.mode || 'forward' }})
+    name: Compatibility tests (${{ inputs.mode }}, ${{ inputs.releasedImage }} <-> main)
     # prevent running on forks
     if: github.repository_owner == 'restatedev'
     runs-on: warp-ubuntu-latest-x64-16x # warpbuild runner
@@ -65,10 +74,11 @@ jobs:
       - name: Run the verification test
         env:
           RESTATE_CONTAINER_IMAGE: "ghcr.io/restatedev/restate:main"
-          SERVICES_CONTAINER_IMAGE: ${{ inputs.sdkImage || 'ghcr.io/restatedev/test-services-node:main' }}
+          RESTATE_RELEASED_CONTAINER_IMAGE: ${{ inputs.releasedImage }}
+          SERVICES_CONTAINER_IMAGE: ${{ inputs.sdkImage }}
           ENV_FILE: "compatibility/env.json"
           PARAMS_FILE: "compatibility/params.json"
-          MODE: ${{ inputs.mode || 'forward' }}
+          MODE: ${{ inputs.mode }}
           RESTATE_LOG_FILTER: ${{ inputs.restateLogFilter || 'restate=info' }}
         run: ./scripts/run-verification.sh
 


### PR DESCRIPTION

Make it possible to choose different base image for the comptability tests in the workflow definition (support is already there in code).
Then change the nightly run to test both 1.6.2 (the default) to main, but also 1.7.0 to main to catch any compatibility regressions in
patch releases.
