### PR TITLE
Integration API with kafka integration correctness tests

### DIFF
--- a/.github/workflows/verification-kafka.yaml
+++ b/.github/workflows/verification-kafka.yaml
@@ -1,0 +1,54 @@
+name: Verification tests - Kafka
+
+on:
+  workflow_dispatch: # To start from UI
+    inputs:
+      restateContainerImage:
+        description: "The restate container image"
+        required: true
+        default: "ghcr.io/restatedev/restate:main"
+      sdkImage:
+        description: "sdk image, will use 'ghcr.io/restatedev/test-services-java:main' when unspecified"
+        required: false
+        default: "ghcr.io/restatedev/test-services-java:main"
+        type: string
+      integrationImage:
+        description: "Integration image"
+        required: false
+        default: "ghcr.io/restatedev/ingress-integration-kafka:main"
+        type: string
+  schedule:
+    - cron: "12 0 * * *" # 00:12am UTC daily
+
+env:
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
+  GHCR_REGISTRY: "ghcr.io"
+  GHCR_REGISTRY_USERNAME: ${{ github.actor }}
+  GHCR_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    # prevent running on forks
+    if: github.repository_owner == 'restatedev'
+    runs-on: warp-ubuntu-latest-x64-16x # warpbuild runner
+    timeout-minutes: 250
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into GitHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ env.GHCR_REGISTRY_USERNAME }}
+          password: ${{ env.GHCR_REGISTRY_TOKEN }}
+
+      - name: Run the verification test
+        env:
+          # todo(azmy): Change this image to main once the integration image PR is merged
+          RESTATE_CONTAINER_IMAGE: ${{ inputs.restateContainerImage || 'ghcr.io/restatedev/restate:pr5026' }}
+          SERVICES_CONTAINER_IMAGE: ${{ inputs.sdkImage || 'ghcr.io/restatedev/test-services-node:main' }}
+          INTEGRATION_IMAGE: ${{ inputs.integrationImage || 'ghcr.io/restatedev/ingress-integration-kafka:main' }}
+          ENV_FILE: "kafka/env.json"
+          PARAMS_FILE: "kafka/params.json"
+        run: ./scripts/run-verification-kafka.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/claude-code) when working with this repository.
+
+## Project Overview
+
+This is the **E2E Verification Runner** for [Restate](https://restate.dev/), a TypeScript/Node.js project that runs end-to-end verification tests. It uses an interpreter-based testing framework to validate Restate services.
+
+## Build & Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Build the TypeScript project
+npm run build
+
+# Run linting
+npm run lint
+
+# Format code
+npm run format
+
+# Run as webapp
+SERVICES=InterpreterDriver node dist/app.js
+
+# Run as standalone job
+SERVICES=InterpreterDriverJob node dist/app.js
+```
+
+## Architecture
+
+- **Entry point**: `src/app.ts` - Routes to interpreter driver based on `SERVICES` env var
+- **Core interpreter**: `src/interpreter/` - Contains the test generation and execution logic
+  - `entry_point.ts` - Exports `interpreterDriver` and `interpreterDriverJob`
+  - `test_generator.ts` - Generates test cases
+  - `test_driver.ts` - Drives test execution
+  - `interpreter.ts` - Core interpreter logic
+  - `commands.ts` - Command definitions
+  - `infra.ts` - Infrastructure utilities
+  - `raw_client.ts` - Raw client implementation
+
+## Key Dependencies
+
+- `@restatedev/restate-sdk-clients` - Restate SDK client library
+- `testcontainers` - For running containerized tests
+
+## Scripts Directory
+
+The `scripts/` directory contains various test scenarios:
+- `run-verification.sh` - Main verification script
+- `run-verification-nodocker.sh` - Tests without Docker
+- Subdirectories for specific test types: `correctness/`, `compatibility/`, `perf/`, `snapshotting/`, `vqueues/`, `s3metastore/`
+
+## TypeScript Configuration
+
+- Target: ESNext
+- Module: Node16
+- Strict mode enabled
+- Output directory: `./dist`

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint": "eslint --ignore-path .eslintignore --ext .ts src",
     "format": "prettier --ignore-path .eslintignore --write \"src/**/*.+(js|ts|json)\"",
     "app": "node ./dist/app.js"
-
   },
   "author": "Restate developers",
   "dependencies": {
     "@restatedev/restate-sdk-clients": "dev",
+    "@testcontainers/kafka": "^10.28.0",
+    "kafkajs": "^2.2.4",
     "testcontainers": "^10.9.0"
   },
   "devDependencies": {

--- a/scripts/kafka/env.json
+++ b/scripts/kafka/env.json
@@ -1,0 +1,153 @@
+{
+  "n1": {
+    "image": "${RESTATE_CONTAINER_IMAGE}",
+    "ports": [
+      8080,
+      9070,
+      5122
+    ],
+    "pull": "always",
+    "env": {
+      "RUST_BACKTRACE": "full",
+      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FORMAT": "json",
+      "RESTATE_ROLES": "[worker,http-ingress,log-server,admin,metadata-server]",
+      "RESTATE_CLUSTER_NAME": "foobar",
+      "RESTATE_DEFAULT_REPLICATION": "2",
+      "RESTATE_BIFROST__DEFAULT_PROVIDER": "replicated",
+      "RESTATE_METADATA_SERVER__TYPE": "replicated",
+      "RESTATE_AUTO_PROVISION": "true",
+      "RESTATE_ADVERTISED_ADDRESS": "http://n1:5122",
+      "RESTATE_INGRESS__INTEGRATION__ENABLED": "true",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
+      "DO_NOT_TRACK": "true"
+    }
+  },
+  "n2": {
+    "image": "${RESTATE_CONTAINER_IMAGE}",
+    "ports": [
+      8080
+    ],
+    "pull": "always",
+    "env": {
+      "RUST_BACKTRACE": "full",
+      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FORMAT": "json",
+      "RESTATE_ROLES": "[worker,http-ingress,log-server,admin,metadata-server]",
+      "RESTATE_CLUSTER_NAME": "foobar",
+      "RESTATE_DEFAULT_REPLICATION": "2",
+      "RESTATE_BIFROST__DEFAULT_PROVIDER": "replicated",
+      "RESTATE_METADATA_SERVER__TYPE": "replicated",
+      "RESTATE_AUTO_PROVISION": "false",
+      "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
+      "RESTATE_ADVERTISED_ADDRESS": "http://n2:5122",
+      "RESTATE_INGRESS__INTEGRATION__ENABLED": "true",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
+      "DO_NOT_TRACK": "true"
+    }
+  },
+  "n3": {
+    "image": "${RESTATE_CONTAINER_IMAGE}",
+    "ports": [
+      8080
+    ],
+    "pull": "always",
+    "env": {
+      "RUST_BACKTRACE": "full",
+      "RESTATE_LOG_FILTER": "restate=warn",
+      "RESTATE_LOG_FORMAT": "json",
+      "RESTATE_ROLES": "[worker,http-ingress,log-server,admin,metadata-server]",
+      "RESTATE_CLUSTER_NAME": "foobar",
+      "RESTATE_BIFROST__DEFAULT_PROVIDER": "replicated",
+      "RESTATE_DEFAULT_REPLICATION": "2",
+      "RESTATE_METADATA_SERVER__TYPE": "replicated",
+      "RESTATE_AUTO_PROVISION": "false",
+      "RESTATE_METADATA_CLIENT__ADDRESSES": "[http://n1:5122]",
+      "RESTATE_ADVERTISED_ADDRESS": "http://n3:5122",
+      "RESTATE_INGRESS__INTEGRATION__ENABLED": "true",
+      "RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT": "256",
+      "RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT": "1sec",
+      "DO_NOT_TRACK": "true"
+    }
+  },
+  "kafka": {
+    "image": "${KAFKA_IMAGE}",
+    "kind": "kafka",
+    "ports": [],
+    "pull": "always",
+    "env": {}
+  },
+  "integration": {
+    "image": "${INTEGRATION_IMAGE}",
+    "ports": [],
+    "pull": "always",
+    "env": {
+      "KAFKA_BOOTSTRAP_SERVERS": "kafka:9092",
+      "KAFKA_GROUP_ID": "restate-integration",
+      "KAFKA_TOPICS": "interpreter",
+      "KAFKA_AUTO_OFFSET_RESET": "earliest",
+      "RESTATE_INGRESS_URL": "http://n1:8080",
+      "RESTATE_RECORD_MAPPER_SERVICE": "ObjectInterpreterL0",
+      "RESTATE_RECORD_MAPPER_HANDLER": "interpret",
+      "RESTATE_KAFKA_CONSUMER_INSTANCES": "4"
+    }
+  },
+  "interpreter_zero": {
+    "image": "${SERVICES_CONTAINER_IMAGE}",
+    "ports": [],
+    "pull": "always",
+    "env": {
+      "PORT": "9000",
+      "RESTATE_LOGGING": "ERROR",
+      "NODE_ENV": "production",
+      "UV_THREADPOOL_SIZE": "8",
+      "NODE_OPTS": "--max-old-space-size=4096",
+      "SERVICES": "ObjectInterpreterL0",
+      "RESTATE_CORE_LOG": "error"
+    }
+  },
+  "interpreter_one": {
+    "image": "${SERVICES_CONTAINER_IMAGE}",
+    "ports": [],
+    "pull": "always",
+    "env": {
+      "PORT": "9001",
+      "RESTATE_LOGGING": "ERROR",
+      "NODE_ENV": "production",
+      "UV_THREADPOOL_SIZE": "8",
+      "NODE_OPTS": "--max-old-space-size=4096",
+      "SERVICES": "ObjectInterpreterL1",
+      "RESTATE_CORE_LOG": "error"
+    }
+  },
+  "interpreter_two": {
+    "image": "${SERVICES_CONTAINER_IMAGE}",
+    "ports": [],
+    "pull": "always",
+    "env": {
+      "PORT": "9002",
+      "RESTATE_LOGGING": "ERROR",
+      "NODE_ENV": "production",
+      "UV_THREADPOOL_SIZE": "8",
+      "NODE_OPTS": "--max-old-space-size=4096",
+      "SERVICES": "ObjectInterpreterL2",
+      "RESTATE_CORE_LOG": "error"
+    }
+  },
+  "services": {
+    "image": "${SERVICES_CONTAINER_IMAGE}",
+    "ports": [],
+    "pull": "always",
+    "env": {
+      "PORT": "9003",
+      "RESTATE_LOGGING": "ERROR",
+      "NODE_ENV": "production",
+      "UV_THREADPOOL_SIZE": "8",
+      "NODE_OPTS": "--max-old-space-size=4096",
+      "SERVICES": "ServiceInterpreterHelper",
+      "RESTATE_CORE_LOG": "error"
+    }
+  }
+}

--- a/scripts/kafka/params.json
+++ b/scripts/kafka/params.json
@@ -1,0 +1,12 @@
+{
+	"seed": "${SEED}",
+	"keys": 1000000,
+	"tests": 100000,
+	"maxProgramSize": 20,
+	"bootstrap": true,
+	"kafka": {
+		"broker": "kafka",
+		"topic": "interpreter",
+		"partitions": 100
+	}
+}

--- a/scripts/run-verification-kafka.sh
+++ b/scripts/run-verification-kafka.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
 
-# The driver is piped into `tee` at the end so its output is also captured to a
-# file that CI uploads as an artifact (the GitHub run-log archive is too large
-# to download reliably). pipefail makes the script's exit status reflect the
-# driver's exit rather than tee's.
-set -o pipefail
+#
+# Runs the verification suite against a 3-node Restate cluster where the driver
+# submits interpreter programs by producing them to a Kafka topic. An
+# `ingress-integration-kafka` container consumes the topic and relays each record
+# into Restate via the gRPC IntegrationSvc (RESTATE_INGRESS__INTEGRATION__ENABLED).
+#
+# NOTE: RESTATE_CONTAINER_IMAGE must be a build that includes the Integration API
+# (restatedev/restate#5026); otherwise the gRPC IntegrationSvc is UNIMPLEMENTED
+# and no records land. Override it, e.g.:
+#   RESTATE_CONTAINER_IMAGE=ghcr.io/restatedev/restate:<pr-build> ./run-verification-kafka.sh
+#
 
 #
 # input parameters to this script, they all have defaults
 #
 export DRIVER_IMAGE=${DRIVER_IMAGE:-"ghcr.io/restatedev/e2e-verification-runner:main"}
-export RESTATE_CONTAINER_IMAGE=${RESTATE_CONTAINER_IMAGE:-"ghcr.io/restatedev/restate:main"}
-export RESTATE_RELEASED_CONTAINER_IMAGE=${RESTATE_RELEASED_CONTAINER_IMAGE:-"restatedev/restate:1.6.2"}
+export RESTATE_CONTAINER_IMAGE=${RESTATE_CONTAINER_IMAGE:-"ghcr.io/restatedev/restate:pr5026"}
 export SERVICES_CONTAINER_IMAGE=${SERVICES_CONTAINER_IMAGE:-"ghcr.io/restatedev/test-services-node:main"}
-export ENV_FILE=${ENV_FILE:-"correctness/env.json"}
-export PARAMS_FILE=${PARAMS_FILE:-"correctness/params.json"}
+export KAFKA_IMAGE=${KAFKA_IMAGE:-"confluentinc/cp-kafka:7.5.0"}
+export INTEGRATION_IMAGE=${INTEGRATION_IMAGE:-"ghcr.io/restatedev/ingress-integration-kafka:main"}
+export ENV_FILE=${ENV_FILE:-"kafka/env.json"}
+export PARAMS_FILE=${PARAMS_FILE:-"kafka/params.json"}
 export MODE=${MODE:-"forward"}
 
 
@@ -62,8 +69,9 @@ function fix_path() {
 if [ -z "${NO_PULL}" ]; then
 	docker pull ${DRIVER_IMAGE}
 	docker pull ${RESTATE_CONTAINER_IMAGE}
-	docker pull ${RESTATE_RELEASED_CONTAINER_IMAGE}
 	docker pull ${SERVICES_CONTAINER_IMAGE}
+	docker pull ${KAFKA_IMAGE}
+	docker pull ${INTEGRATION_IMAGE}
 fi
 
 # log configuration parameters
@@ -75,13 +83,15 @@ echo "RESTATE ================================================"
 echo ${RESTATE_CONTAINER_IMAGE}
 docker inspect ${RESTATE_CONTAINER_IMAGE} | grep org.opencontainers.image.revision
 
-echo "RESTATE (released) ========================================="
-echo ${RESTATE_RELEASED_CONTAINER_IMAGE}
-docker inspect ${RESTATE_RELEASED_CONTAINER_IMAGE} | grep org.opencontainers.image.revision
-
 echo "SERVICE ================================================"
 echo ${SERVICES_CONTAINER_IMAGE}
 docker inspect ${SERVICES_CONTAINER_IMAGE} | grep org.opencontainers.image.revision
+
+echo "KAFKA ================================================="
+echo ${KAFKA_IMAGE}
+
+echo "INTEGRATION ==========================================="
+echo ${INTEGRATION_IMAGE}
 
 echo "======================================================="
 
@@ -97,25 +107,13 @@ echo ${PARAMS_FILE}
 export MOUNT_DIR=$(mktemp -d)
 echo "MOUNT_DIR=${MOUNT_DIR}"
 
-# Directory for all logs uploaded as a CI artifact: the driver's own output
-# (verification.log) plus one file per container, written by the driver into the
-# mounted container-logs dir.
-export LOG_DIR=${LOG_DIR:-"$(pwd)/logs"}
-export CONTAINER_LOGS_DIR_HOST="${LOG_DIR}/containers"
-mkdir -p "${CONTAINER_LOGS_DIR_HOST}"
-export VERIFICATION_LOG="${VERIFICATION_LOG:-${LOG_DIR}/verification.log}"
-
-# Separate dir (outside LOG_DIR) for the large restate-data dumps, uploaded as its
-# own CI artifact so the logs can be downloaded without pulling multi-GB RocksDB data.
-export RESTATE_DATA_DUMP_DIR_HOST="${RESTATE_DATA_DUMP_DIR_HOST:-$(pwd)/restate-data}"
-mkdir -p "${RESTATE_DATA_DUMP_DIR_HOST}"
-
 export INTERPRETER_DRIVER_CONF=$(template_json ${PARAMS_FILE})
 export UNIVERSE_ENV_JSON=$(template_json ${ENV_FILE})
 export SERVICES=InterpreterDriverJob
 export NODE_ENV=production
 export NODE_OPTIONS="--max-old-space-size=4096"
 export AWS_LAMBDA_FUNCTION_NAME=1
+export DEBUG=testcontainers:containers
 
 if [ -n "${DISABLE_CLEANUP}" ]; then
 	export TESTCONTAINERS_RYUK_DISABLED=true
@@ -128,17 +126,9 @@ docker run \
 	--env NODE_ENV \
 	--env NODE_OPTIONS \
 	--env AWS_LAMBDA_FUNCTION_NAME \
-	-v "${CONTAINER_LOGS_DIR_HOST}":/container-logs \
-	--env CONTAINER_LOGS_DIR=/container-logs \
-	-v "${RESTATE_DATA_DUMP_DIR_HOST}":/restate-data-dump \
-	--env RESTATE_DATA_DUMP_DIR=/restate-data-dump \
+	--env DEBUG \
 	--env INTERPRETER_DRIVER_CONF \
 	--env UNIVERSE_ENV_JSON \
 	--env DISABLE_CLEANUP \
 	--env TESTCONTAINERS_RYUK_DISABLED \
-	--env STUCK_DETECTOR_DUMP_GOROUTINES \
-	--env STUCK_DETECTOR_DUMP_DATA \
-	--env STUCK_DETECTOR_TIMEOUT_SECONDS \
-	--env STUCK_DETECTOR_DISABLED \
-	--env INTERPRETER_JOURNAL_RETENTION \
-	${DRIVER_IMAGE} 2>&1 | tee "${VERIFICATION_LOG:-verification.log}"
+	${DRIVER_IMAGE}

--- a/src/interpreter/infra.ts
+++ b/src/interpreter/infra.ts
@@ -20,6 +20,8 @@ import {
 } from "testcontainers";
 import { createWriteStream, WriteStream } from "fs";
 import { pipeline } from "stream/promises";
+import { KafkaContainer } from "@testcontainers/kafka";
+import { Readable } from "stream";
 import { TestConfigurationRollingUpgrade } from "./test_driver";
 
 // Directory (inside the driver container) where each container's full log is
@@ -48,6 +50,12 @@ function attachLogStream(
     builder.withLogConsumer((s) => s.pipe(stream, { end: false }));
   }
 }
+
+// The host-exposed PLAINTEXT port of the @testcontainers/kafka KafkaContainer.
+// Host clients (the driver runs with --net host) reach the broker at
+// getHost():getMappedPort(KAFKA_HOST_PORT); in-network clients use the
+// BROKER listener at <alias>:9092 (see the kafka branch in start()).
+const KAFKA_HOST_PORT = 9093;
 
 export type ClusterSpec = {
   containers: ContainerSpec[];
@@ -78,6 +86,11 @@ export type ContainerSpec = {
   entryPoint?: string[];
   // mount the following volumes (always rw mode)
   mount?: { source: string; target: string }[];
+  // the kind of container to start. "generic" (default) starts a plain
+  // GenericContainer. "kafka" starts a KafkaContainer (KRaft/zookeeper +
+  // advertised-listener handling); its host bootstrap address is obtained via
+  // Cluster.hostBootstrapServers(name).
+  kind?: "generic" | "kafka";
 };
 
 export type Container = {
@@ -115,6 +128,9 @@ export type Cluster = {
   containerNames(): string[];
   hostContainerUrl(name: string, port: number): string;
   internalContainerUrl(name: string, port: number): string;
+  // "host:port" bootstrap address of a kind:"kafka" container, reachable from
+  // the host (the driver). In-network clients should instead use "<name>:9092".
+  hostBootstrapServers(name: string): string;
 };
 
 export function createCluster(spec: ClusterSpec): Cluster {
@@ -132,7 +148,7 @@ class ConfiguredContainer implements Container {
     private started: StartedTestContainer | undefined,
     private readonly mode: "none" | "forward" | "backward" | "random",
     private readonly logStream?: WriteStream,
-  ) {}
+  ) { }
 
   get name() {
     return this.spec.name;
@@ -341,7 +357,7 @@ class ConfiguredCluster implements Cluster {
   private containers: Map<string, ConfiguredContainer> | undefined;
   private network: StartedNetwork | undefined;
 
-  constructor(private readonly spec: ClusterSpec) {}
+  constructor(private readonly spec: ClusterSpec) { }
 
   hostContainerUrl(name: string, port: number): string {
     if (this.containers === undefined) {
@@ -365,6 +381,17 @@ class ConfiguredCluster implements Cluster {
     return `http://${container.host()}:${port}`;
   }
 
+  hostBootstrapServers(name: string): string {
+    if (this.containers === undefined) {
+      throw new Error("Cluster not started");
+    }
+    const container = this.containers.get(name);
+    if (!container) {
+      throw new Error(`Container ${name} not found`);
+    }
+    return `${container.host()}:${container.port(KAFKA_HOST_PORT)}`;
+  }
+
   async start(rollingUpgrade: TestConfigurationRollingUpgrade): Promise<void> {
     const network = await new Network().start();
 
@@ -379,8 +406,8 @@ class ConfiguredCluster implements Cluster {
 
       const logStream = CONTAINER_LOGS_DIR
         ? createWriteStream(`${CONTAINER_LOGS_DIR}/${spec.name}.log`, {
-            flags: "a",
-          })
+          flags: "a",
+        })
         : undefined;
 
       let ports: PortWithOptionalBinding[] = spec.ports.map((port) => {
@@ -398,59 +425,57 @@ class ConfiguredCluster implements Cluster {
         }
       });
 
-      const container = new GenericContainer(image)
-        .withExposedPorts(...ports)
-        .withNetwork(network)
-        .withNetworkAliases(spec.name)
-        .withName(spec.name)
-        .withPullPolicy(
-          spec.pull === "always" ? PullPolicy.alwaysPull() : neverPoll,
-        )
-        .withEnvironment(spec.env ?? {});
+      const pullPolicy =
+        spec.pull === "always" ? PullPolicy.alwaysPull() : neverPoll;
 
-      if (spec.cmd) {
-        container.withCommand(spec.cmd);
-      }
-      if (spec.entryPoint) {
-        container.withEntrypoint(spec.entryPoint);
-      }
-      if (spec.mount) {
-        container.withBindMounts(
-          spec.mount.map((m) => {
-            return { source: m.source, target: m.target, mode: "rw" };
-          }),
-        );
-      }
-      attachLogStream(container, logStream);
-
-      const restContainers: [string, GenericContainer][] = images.map(
-        (image) => {
-          const restContainer = new GenericContainer(image)
-            .withExposedPorts(...ports)
+      const buildContainer = (image: string): GenericContainer => {
+        if (spec.kind === "kafka") {
+          // KafkaContainer owns its exposed port (KAFKA_HOST_PORT) and the
+          // advertised-listener rewrite. We pin the container hostname to the
+          // network alias so the in-network BROKER listener advertises
+          // "<alias>:9092" (resolvable by other containers) rather than the
+          // random container id.
+          const kafka = new KafkaContainer(image)
             .withNetwork(network)
             .withNetworkAliases(spec.name)
             .withName(spec.name)
-            .withPullPolicy(
-              spec.pull === "always" ? PullPolicy.alwaysPull() : neverPoll,
-            )
+            .withHostname(spec.name)
+            .withPullPolicy(pullPolicy)
             .withEnvironment(spec.env ?? {});
+          attachLogStream(kafka, logStream);
+          return kafka;
+        }
 
-          if (spec.cmd) {
-            restContainer.withCommand(spec.cmd);
-          }
-          if (spec.entryPoint) {
-            restContainer.withEntrypoint(spec.entryPoint);
-          }
-          if (spec.mount) {
-            restContainer.withBindMounts(
-              spec.mount.map((m) => {
-                return { source: m.source, target: m.target, mode: "rw" };
-              }),
-            );
-          }
-          attachLogStream(restContainer, logStream);
+        const c = new GenericContainer(image)
+          .withExposedPorts(...ports)
+          .withNetwork(network)
+          .withNetworkAliases(spec.name)
+          .withName(spec.name)
+          .withPullPolicy(pullPolicy)
+          .withEnvironment(spec.env ?? {});
 
-          return [image, restContainer];
+        if (spec.cmd) {
+          c.withCommand(spec.cmd);
+        }
+        if (spec.entryPoint) {
+          c.withEntrypoint(spec.entryPoint);
+        }
+        if (spec.mount) {
+          c.withBindMounts(
+            spec.mount.map((m) => {
+              return { source: m.source, target: m.target, mode: "rw" };
+            }),
+          );
+        }
+        attachLogStream(c, logStream);
+        return c;
+      };
+
+      const container = buildContainer(image);
+
+      const restContainers: [string, GenericContainer][] = images.map(
+        (image) => {
+          return [image, buildContainer(image)];
         },
       );
 

--- a/src/interpreter/kafka_client.ts
+++ b/src/interpreter/kafka_client.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate e2e tests,
+// which are released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/e2e/blob/main/LICENSE
+
+import { Kafka, Partitioners, type Producer } from "kafkajs";
+import type { Program } from "./commands";
+
+/**
+ * Produces interpreter programs onto a Kafka topic instead of submitting them
+ * over the Restate HTTP ingress. The `ingress-integration-kafka` container
+ * consumes the topic and streams each record into Restate via the gRPC
+ * IntegrationSvc. Its StaticRecordMapper maps the record key to the
+ * virtual-object key and the record value (bytes) to the invocation payload,
+ * targeting a fixed service/handler (ObjectInterpreterL0/interpret), configured
+ * on that container.
+ *
+ * The record key is `interpreterId` and the value is `JSON.stringify(program)`
+ * -- byte-for-byte the same body the HTTP path (`sendInterpreter`) sends.
+ */
+export interface InterpreterProducer {
+  send(interpreterId: string, program: Program): Promise<void>;
+  disconnect(): Promise<void>;
+}
+
+export async function createInterpreterProducer(opts: {
+  brokers: string[];
+  topic: string;
+  partitions: number;
+}): Promise<InterpreterProducer> {
+  const kafka = new Kafka({ clientId: "e2e-driver", brokers: opts.brokers });
+
+  // Pre-create the topic so the consumer (KAFKA_AUTO_OFFSET_RESET=earliest) can
+  // read everything regardless of producer/consumer startup ordering.
+  const admin = kafka.admin();
+  await admin.connect();
+  try {
+    await admin.createTopics({
+      waitForLeaders: true,
+      topics: [
+        {
+          topic: opts.topic,
+          numPartitions: opts.partitions,
+          replicationFactor: 1,
+        },
+      ],
+    }); // idempotent: resolves false if the topic already exists
+  } finally {
+    await admin.disconnect();
+  }
+
+  // Idempotent producer (acks=all, enable.idempotence, in-flight=1) replaces the
+  // per-invocation idempotency-key header, which the static mapper cannot carry.
+  // Cross-rebalance exactly-once into Restate is the integration container's job.
+  const producer: Producer = kafka.producer({
+    idempotent: true,
+    maxInFlightRequests: 1,
+    createPartitioner: Partitioners.DefaultPartitioner,
+  });
+  await producer.connect();
+
+  return {
+    async send(interpreterId: string, program: Program): Promise<void> {
+      await producer.send({
+        topic: opts.topic,
+        messages: [{ key: interpreterId, value: JSON.stringify(program) }],
+      });
+    },
+    async disconnect(): Promise<void> {
+      await producer.disconnect();
+    },
+  };
+}

--- a/src/interpreter/test_driver.ts
+++ b/src/interpreter/test_driver.ts
@@ -19,6 +19,7 @@ import {
   getInvocationStatusCounts,
   sendInterpreter,
 } from "./raw_client";
+import { createInterpreterProducer } from "./kafka_client";
 import { collectDiagnostics, DifferingKey } from "./diagnostics";
 
 // A paused invocation never self-resolves (it waits for a manual resume), so
@@ -80,7 +81,8 @@ const STUCK_DETECTOR_DUMP_GOROUTINES =
 // Capture each runtime node's /restate-data dir on a wedged run. Off by default
 // (the dirs can be large and it gracefully stops the nodes); enable in CI
 // workflows that want the on-disk RocksDB/metadata state for post-mortem.
-const STUCK_DETECTOR_DUMP_DATA = process.env.STUCK_DETECTOR_DUMP_DATA === "true";
+const STUCK_DETECTOR_DUMP_DATA =
+  process.env.STUCK_DETECTOR_DUMP_DATA === "true";
 
 export interface TestConfigurationDeployments {
   adminUrl: string;
@@ -109,6 +111,16 @@ export interface TestConfiguration {
   ///    definition must contain a list of ordered images.
   //     see: ContainerSpec.images in infra.ts
   readonly rollingUpgrade?: TestConfigurationRollingUpgrade;
+  // When set (and running a bootstrapped cluster), the driver submits programs
+  // by producing them to a Kafka topic instead of calling the HTTP ingress. An
+  // `ingress-integration-kafka` container in the cluster consumes the topic and
+  // relays each record into Restate via the gRPC IntegrationSvc. `broker` is the
+  // cluster container name of the kind:"kafka" broker.
+  readonly kafka?: {
+    broker: string;
+    topic: string;
+    partitions: number;
+  };
 }
 
 export enum TestStatus {
@@ -421,6 +433,34 @@ export class Test {
 
     killRestate().catch(console.error);
 
+    if (this.conf.kafka && this.containers) {
+      await this.sendViaKafka(this.conf.kafka, this.containers);
+    } else {
+      await this.sendViaIngress(ingressUrls);
+    }
+
+    this.status = TestStatus.VALIDATING;
+    console.log("Done generating");
+
+    const expected = this.stateTracker.getStates();
+    const numInterpreters = this.conf.keys;
+    const expectedTotal = expected.reduce((acc, layer) => {
+      return acc + layer.reduce((acc, v) => acc + v, 0);
+    }, 0);
+
+    return verify({
+      numInterpreters,
+      adminUrl,
+      expectedTotal,
+      expected,
+      cluster: this.containers,
+    });
+  }
+
+  // Submit programs over the Restate HTTP ingress: one POST per program to
+  // /ObjectInterpreterL0/{id}/interpret/send, round-robin across ingress URLs,
+  // deduplicated by a monotonic idempotency key.
+  private async sendViaIngress(ingressUrls: URL[]) {
     let idempotencyKey = 1;
     for (const b of batch(this.generate(), 256)) {
       const promises = b.map(({ id, program }) => {
@@ -451,23 +491,49 @@ export class Test {
         throw e;
       }
     }
+  }
 
-    this.status = TestStatus.VALIDATING;
-    console.log("Done generating");
-
-    const expected = this.stateTracker.getStates();
-    const numInterpreters = this.conf.keys;
-    const expectedTotal = expected.reduce((acc, layer) => {
-      return acc + layer.reduce((acc, v) => acc + v, 0);
-    }, 0);
-
-    return verify({
-      numInterpreters,
-      adminUrl,
-      expectedTotal,
-      expected,
-      cluster: this.containers,
+  // Submit programs by producing them to a Kafka topic. An
+  // `ingress-integration-kafka` container consumes the topic and relays each
+  // record into Restate via the gRPC IntegrationSvc. The record key is the
+  // interpreter id (-> virtual-object key) and the value is JSON.stringify(program)
+  // (-> invocation payload). The local expectation (stateTracker.update) is
+  // recorded identically to the ingress path, so verification is unchanged.
+  private async sendViaKafka(
+    kafka: NonNullable<TestConfiguration["kafka"]>,
+    containers: Cluster,
+  ) {
+    const brokers = [containers.hostBootstrapServers(kafka.broker)];
+    console.log(`Producing to Kafka topic '${kafka.topic}' via ${brokers}`);
+    const producer = await createInterpreterProducer({
+      brokers,
+      topic: kafka.topic,
+      partitions: kafka.partitions,
     });
+    try {
+      for (const b of batch(this.generate(), 256)) {
+        const promises = b.map(({ id, program }) =>
+          retry({
+            op: () => producer.send(`${id}`, program),
+            timeout: 1000,
+            tag: `produce ${id}`,
+          }),
+        );
+
+        b.forEach(({ id, program }) =>
+          this.stateTracker.update(0, id, program),
+        );
+        try {
+          await Promise.all(promises);
+          console.log(`\x1b[33m Produced ${b.length} programs \x1b[0m`);
+        } catch (e) {
+          console.error(e);
+          throw e;
+        }
+      }
+    } finally {
+      await producer.disconnect();
+    }
   }
 
   private async cleanup() {


### PR DESCRIPTION

Summary:
- Introduce kafka integration correctness tests
- Make sure we run nightly correctness tests against the kafka integration

Note that:
- Right now the kafka integration does not support multiple ingress URL https://github.com/restatedev/ingress-integration-kafka/issues/1
  once this is fixed we can introduce restate crashes/restarts
- This is uses a custom restart image from the API branch, this **must** be changed to main before merging
