### PR TITLE
Run compatibility tests agains v1.7.2

### DIFF
--- a/.github/workflows/verification-compatibility-backward.yaml
+++ b/.github/workflows/verification-compatibility-backward.yaml
@@ -15,6 +15,7 @@ jobs:
         releasedImage:
           - restatedev/restate:1.6.2
           - restatedev/restate:1.7.0
+          - restatedev/restate:1.7.2
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:

--- a/.github/workflows/verification-compatibility-forward.yaml
+++ b/.github/workflows/verification-compatibility-forward.yaml
@@ -15,6 +15,7 @@ jobs:
         releasedImage:
           - restatedev/restate:1.6.2
           - restatedev/restate:1.7.0
+          - restatedev/restate:1.7.2
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:

--- a/.github/workflows/verification-compatibility-random.yaml
+++ b/.github/workflows/verification-compatibility-random.yaml
@@ -15,6 +15,7 @@ jobs:
         releasedImage:
           - restatedev/restate:1.6.2
           - restatedev/restate:1.7.0
+          - restatedev/restate:1.7.2
     uses: ./.github/workflows/verification-compatibility.yaml
     secrets: inherit
     with:


### PR DESCRIPTION

Summary:
To make sure v1.7.3 does not break compatibility
with v1.7.2 we run it in a separate test.

There is a know DF compatibility issue against v1.7.0
that surface randomly by the test driver verifications
queries that can trigger a false negative
